### PR TITLE
🐛 apply OZ's fix for Base64Url

### DIFF
--- a/src/utils/Base64Url.sol
+++ b/src/utils/Base64Url.sol
@@ -1,76 +1,82 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-/**
- * @dev Encode (without '=' padding) 
- * @author evmbrahmin, adapted from hiromin's Base64URL libraries
- */
+/// @notice Library to encode strings in Base64.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/Base64.sol)
+/// @author Modified from Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/Base64.sol)
+/// @author Modified from (https://github.com/Brechtpd/base64/blob/main/base64.sol) by Brecht Devos - <brecht@loopring.org>.
 library Base64Url {
-    /**
-     * @dev Base64Url Encoding Table
-     */
-    string internal constant ENCODING_TABLE =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
-    function encode(bytes memory data) internal pure returns (string memory) {
-        if (data.length == 0) return "";
-
-        // Load the table into memory
-        string memory table = ENCODING_TABLE;
-
-        string memory result = new string(4 * ((data.length + 2) / 3));
-
-        // @solidity memory-safe-assembly
+    /// @dev Encodes `data` using the base64 encoding described in RFC 4648.
+    /// See: https://datatracker.ietf.org/doc/html/rfc4648
+    /// @param fileSafe  Whether to replace '+' with '-' and '/' with '_'.
+    /// @param noPadding Whether to strip away the padding.
+    function encode(bytes memory data, bool fileSafe, bool noPadding) internal pure returns (string memory result) {
+        /// @solidity memory-safe-assembly
         assembly {
-            let tablePtr := add(table, 1)
-            let resultPtr := add(result, 32)
+            let dataLength := mload(data)
 
-            for {
-                let dataPtr := data
-                let endPtr := add(data, mload(data))
-            } lt(dataPtr, endPtr) {
+            if dataLength {
+                // Multiply by 4/3 rounded up.
+                // The `shl(2, ...)` is equivalent to multiplying by 4.
+                let encodedLength := shl(2, div(add(dataLength, 2), 3))
 
-            } {
-                dataPtr := add(dataPtr, 3)
-                let input := mload(dataPtr)
+                // Set `result` to point to the start of the free memory.
+                result := mload(0x40)
 
-                mstore8(
-                    resultPtr,
-                    mload(add(tablePtr, and(shr(18, input), 0x3F)))
-                )
-                resultPtr := add(resultPtr, 1)
+                // Store the table into the scratch space.
+                // Offsetted by -1 byte so that the `mload` will load the character.
+                // We will rewrite the free memory pointer at `0x40` later with
+                // the allocated size.
+                // The magic constant 0x0670 will turn "-_" into "+/".
+                mstore(0x1f, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef")
+                mstore(0x3f, xor("ghijklmnopqrstuvwxyz0123456789-_", mul(iszero(fileSafe), 0x0670)))
 
-                mstore8(
-                    resultPtr,
-                    mload(add(tablePtr, and(shr(12, input), 0x3F)))
-                )
-                resultPtr := add(resultPtr, 1)
+                // Skip the first slot, which stores the length.
+                let ptr := add(result, 0x20)
+                let end := add(ptr, encodedLength)
 
-                mstore8(
-                    resultPtr,
-                    mload(add(tablePtr, and(shr(6, input), 0x3F)))
-                )
-                resultPtr := add(resultPtr, 1)
+                let dataEnd := add(add(0x20, data), dataLength)
+                let dataEndValue := mload(dataEnd) // Cache the value at the `dataEnd` slot.
+                mstore(dataEnd, 0x00) // Zeroize the `dataEnd` slot to clear dirty bits.
 
-                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
-                resultPtr := add(resultPtr, 1)
+                // Run over the input, 3 bytes at a time.
+                for {} 1 {} {
+                    data := add(data, 3) // Advance 3 bytes.
+                    let input := mload(data)
+
+                    // Write 4 bytes. Optimized for fewer stack operations.
+                    mstore8(0, mload(and(shr(18, input), 0x3F)))
+                    mstore8(1, mload(and(shr(12, input), 0x3F)))
+                    mstore8(2, mload(and(shr(6, input), 0x3F)))
+                    mstore8(3, mload(and(input, 0x3F)))
+                    mstore(ptr, mload(0x00))
+
+                    ptr := add(ptr, 4) // Advance 4 bytes.
+                    if iszero(lt(ptr, end)) { break }
+                }
+                mstore(dataEnd, dataEndValue) // Restore the cached value at `dataEnd`.
+                mstore(0x40, add(end, 0x20)) // Allocate the memory.
+                // Equivalent to `o = [0, 2, 1][dataLength % 3]`.
+                let o := div(2, mod(dataLength, 3))
+                // Offset `ptr` and pad with '='. We can simply write over the end.
+                mstore(sub(ptr, o), shl(240, 0x3d3d))
+                // Set `o` to zero if there is padding.
+                o := mul(iszero(iszero(noPadding)), o)
+                mstore(sub(ptr, o), 0) // Zeroize the slot after the string.
+                mstore(result, sub(encodedLength, o)) // Store the length.
             }
-
-            // Remove the padding adjustment logic
-            switch mod(mload(data), 3)
-            case 1 {
-                // Adjust for the last byte of data
-                resultPtr := sub(resultPtr, 2)
-            }
-            case 2 {
-                // Adjust for the last two bytes of data
-                resultPtr := sub(resultPtr, 1)
-            }
-            
-            // Set the correct length of the result string
-            mstore(result, sub(resultPtr, add(result, 32)))
         }
+    }
 
-        return result;  
+    /// @dev Encodes `data` using the base64 encoding described in RFC 4648.
+    /// Equivalent to `encode(data, false, false)`.
+    function encode(bytes memory data) internal pure returns (string memory result) {
+        result = encode(data, false, false);
+    }
+
+    /// @dev Encodes `data` using the base64 encoding described in RFC 4648.
+    /// Equivalent to `encode(data, fileSafe, false)`.
+    function encode(bytes memory data, bool fileSafe) internal pure returns (string memory result) {
+        result = encode(data, fileSafe, false);
     }
 }


### PR DESCRIPTION
Update the Base64Url.sol file to the latest version from Solmate's main branch that includes the fix
highlighted by the OZ team recently.

--

As this file is not used in the repository at all, I would suggest removing it or at least importing the Solady library to use their implementation (https://github.com/Vectorized/solady/blob/main/src/utils/Base64.sol). That will improve the maintenance.